### PR TITLE
conda doctor init, typing tweaks

### DIFF
--- a/conda/plugins/subcommands/doctor/__init__.py
+++ b/conda/plugins/subcommands/doctor/__init__.py
@@ -1,3 +1,0 @@
-# Copyright (C) 2012 Anaconda, Inc
-# SPDX-License-Identifier: BSD-3-Clause
-from . import health_checks  # noqa F401

--- a/conda/plugins/subcommands/doctor/cli.py
+++ b/conda/plugins/subcommands/doctor/cli.py
@@ -10,8 +10,6 @@ from ....cli.conda_argparse import add_parser_prefix
 from ....base.context import locate_prefix_by_name, context
 from ....exceptions import CondaError
 
-from . import health_checks
-
 
 def get_parsed_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -55,13 +53,15 @@ def get_prefix(args: argparse.Namespace) -> str:
     if args.prefix:
         return validate_prefix(args.prefix)
 
-    return context.active_prefix
+    # context.active_prefix can return None; always return str
+    return context.active_prefix or ""
 
 
 def display_health_checks(prefix: str, verbose: bool = False) -> None:
     """
-    TODO: docstring
+    Display health checks.
     """
+    from . import health_checks
     if verbose:
         health_checks.display_detailed_health_checks(prefix)
     else:
@@ -70,7 +70,7 @@ def display_health_checks(prefix: str, verbose: bool = False) -> None:
 
 def execute(argv: list[str]) -> None:
     """
-    TODO: docstring
+    Run conda doctor subcommand.
     """
     args = get_parsed_args(argv)
     prefix = get_prefix(args)

--- a/conda/plugins/subcommands/doctor/health_checks.py
+++ b/conda/plugins/subcommands/doctor/health_checks.py
@@ -32,7 +32,7 @@ def get_number_of_missing_files(prefix: str) -> dict[str, int]:
     return {k: len(v) for k, v in packages_with_missing_files.items()}
 
 
-def find_packages_with_missing_files(prefix: str) -> dict[str, list[str]]:
+def find_packages_with_missing_files(prefix: str | Path) -> dict[str, list[str]]:
     """
     Finds packages listed in conda-meta which have missing files
     """


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

`__init__.py` should be optional in Python 3.3+

Delay `health_checks` import until the command is run (since it usually won't be).

A couple of type checker tweaks.
